### PR TITLE
Spinner on loading

### DIFF
--- a/src/app/dex/loading.tsx
+++ b/src/app/dex/loading.tsx
@@ -1,0 +1,7 @@
+import Spinner from "@/components/common/spinner"
+
+export default function Loading() {
+	return <div className="justify-center w-1/2 h-1/2">
+    <Spinner />
+</div>
+}

--- a/src/app/dex/page.tsx
+++ b/src/app/dex/page.tsx
@@ -58,7 +58,7 @@ export default function Dex() {
 	useEffect(() => {
 		updateUserOrders();
 		loadTokens();
-    setIsInitialized(true)
+		setIsInitialized(true)
 	}, []);
 
 	useEffect(() => {

--- a/src/app/dex/page.tsx
+++ b/src/app/dex/page.tsx
@@ -40,7 +40,7 @@ export default function Dex() {
 	const [expireNumber, expireUnit, convertToMillis, setExpiration] =
 		useExpire();
 	const isConnected = useRef<boolean>();
-  const [isInitialized, setIsInitialized] = useState(false);
+	const [isInitialized, setIsInitialized] = useState(false);
 
 	const orderBookOrders = useOrderBookOrders(buy, sell, contractRef.current);
 

--- a/src/app/dex/page.tsx
+++ b/src/app/dex/page.tsx
@@ -20,7 +20,8 @@ import type { Amount, DetailedOrder } from "@/types";
 import { BN_ZERO } from "@polkadot/util";
 import { useRouter } from "next/navigation";
 import { Rule } from "postcss";
-import { useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
+import Loading from "./loading";
 
 type TokenData = TokenWithPrice & {
 	amount: Amount;
@@ -353,6 +354,8 @@ export default function Dex() {
 							</div>
 						</div>
 					</div>
+
+          <Suspense fallback={<Loading />}>
 					<div className="md:has-[table]:py-12 md:py-5 pl-5 basis-2/5">
 						<OrderBook
 							orders={orderBookOrders}
@@ -362,11 +365,14 @@ export default function Dex() {
 							selectedOrder={order}
 						/>
 					</div>
+          </Suspense>
 				</div>
 			</div>
+      <Suspense fallback={<Loading />}>
 			<div className="py-[75px] w-full ">
 				<OrdersList orders={userOrders} cancelOrder={onCancelOrder} />
 			</div>
+      </Suspense>
 		</div>
 	);
 }

--- a/src/app/dex/page.tsx
+++ b/src/app/dex/page.tsx
@@ -29,7 +29,6 @@ type TokenData = TokenWithPrice & {
 
 export default function Dex() {
 	const contractRef = useRef<Contract>(new Contract());
-
 	const [isMaker, setIsMaker] = useState<boolean>(false);
 	const [sell, setSell] = useState<TokenData>();
 	const [buy, setBuy] = useState<TokenData>();
@@ -41,6 +40,7 @@ export default function Dex() {
 	const [expireNumber, expireUnit, convertToMillis, setExpiration] =
 		useExpire();
 	const isConnected = useRef<boolean>();
+  const [isInitialized, setIsInitialized] = useState(false);
 
 	const orderBookOrders = useOrderBookOrders(buy, sell, contractRef.current);
 
@@ -58,6 +58,7 @@ export default function Dex() {
 	useEffect(() => {
 		updateUserOrders();
 		loadTokens();
+    setIsInitialized(true)
 	}, []);
 
 	useEffect(() => {
@@ -370,7 +371,9 @@ export default function Dex() {
 			</div>
       <Suspense fallback={<Loading />}>
 			<div className="py-[75px] w-full ">
-				<OrdersList orders={userOrders} cancelOrder={onCancelOrder} />
+				<OrdersList orders={userOrders} cancelOrder={onCancelOrder}
+        isInitialized={isInitialized}
+        />
 			</div>
       </Suspense>
 		</div>

--- a/src/app/dex/page.tsx
+++ b/src/app/dex/page.tsx
@@ -214,12 +214,12 @@ export default function Dex() {
 		<div className="text-GGx-gray flex flex-col w-full items-center">
 			<div className="flex flex-col w-full">
 				<div className="flex text-xl justify-between text-[30px] pb-[10px]">
-					<button onClick={() => setIsMaker(false)}>
+					<button onClick={() => setIsMaker(false)} type="button" >
 						<p className={isTaker ? "text-GGx-yellow" : "text-GGx-gray"}>
 							Taker order
 						</p>
 					</button>
-					<button onClick={() => setIsMaker(true)}>
+					<button onClick={() => setIsMaker(true)} type="button">
 						<p className={isMaker ? "text-GGx-yellow" : "text-GGx-gray"}>
 							Maker order
 						</p>
@@ -259,7 +259,7 @@ export default function Dex() {
 										The balance is not enough to make this swap
 									</p>
 									{isMaker && ( // Taker can't regulate the amount of the order.
-										<button
+										<button type="button"
 											className="ml-2 p-1 rounded-2xl border grow-on-hover"
 											onClick={() =>
 												setSell({ ...sell, amount: availableBalanceNormalized })

--- a/src/app/transfer/loading.tsx
+++ b/src/app/transfer/loading.tsx
@@ -1,0 +1,7 @@
+import Spinner from "@/components/common/spinner"
+
+export default function Loading() {
+	return <div className="justify-center w-1/2 h-1/2">
+    <Spinner />
+</div>
+}

--- a/src/app/transfer/page.tsx
+++ b/src/app/transfer/page.tsx
@@ -19,12 +19,13 @@ import {
 import type { AccountData, ChainInfo } from "@keplr-wallet/types";
 import { Keyring } from "@polkadot/keyring";
 import { BN, BN_ZERO, u8aToHex } from "@polkadot/util";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "react-toastify";
 
 import { Button } from "@/components/common/button";
 import Ruler from "@/components/common/ruler";
 import TokenDecimals from "@/tokenDecimalsConverter";
+import Loading from "./loading";
 
 type ModalTypes = "Deposit" | "Withdraw";
 
@@ -357,6 +358,7 @@ export default function Transfer() {
 						/>
 					</div>
 				</div>
+        <Suspense fallback={<Loading />}>
 				<TokenList
 					selected={selectedToken}
 					onClick={setSelectedToken}
@@ -365,6 +367,7 @@ export default function Transfer() {
 					}`}
 					tokens={tokens}
 				/>
+        </Suspense>
 			</div>
 
 			<Modal

--- a/src/app/transfer/page.tsx
+++ b/src/app/transfer/page.tsx
@@ -57,7 +57,7 @@ export default function Transfer() {
 		const a = async () => {
 			await connectWallet();
 			await connectGGxWallet();
-      setIsInitialized(true)
+			setIsInitialized(true)
 		};
 		a();
 	}, [chain]);

--- a/src/app/transfer/page.tsx
+++ b/src/app/transfer/page.tsx
@@ -30,7 +30,7 @@ import Loading from "./loading";
 type ModalTypes = "Deposit" | "Withdraw";
 
 export default function Transfer() {
-  const [isInitialized, setIsInitialized] = useState(false);
+	const [isInitialized, setIsInitialized] = useState(false);
 	const chains = ibcChains;
 	const [chain, setChain] = useState<ChainInfo>(ibcChains[0]);
 	const [client, setClient] = useState<SigningStargateClient>();

--- a/src/app/transfer/page.tsx
+++ b/src/app/transfer/page.tsx
@@ -30,6 +30,7 @@ import Loading from "./loading";
 type ModalTypes = "Deposit" | "Withdraw";
 
 export default function Transfer() {
+  const [isInitialized, setIsInitialized] = useState(false);
 	const chains = ibcChains;
 	const [chain, setChain] = useState<ChainInfo>(ibcChains[0]);
 	const [client, setClient] = useState<SigningStargateClient>();
@@ -56,6 +57,7 @@ export default function Transfer() {
 		const a = async () => {
 			await connectWallet();
 			await connectGGxWallet();
+      setIsInitialized(true)
 		};
 		a();
 	}, [chain]);
@@ -366,6 +368,7 @@ export default function Transfer() {
 						walletIsNotInitialized ? "opacity-50" : "opacity-100"
 					}`}
 					tokens={tokens}
+          isInitialized={isInitialized}
 				/>
         </Suspense>
 			</div>

--- a/src/app/wallet/loading.tsx
+++ b/src/app/wallet/loading.tsx
@@ -1,0 +1,7 @@
+import Spinner from "@/components/common/spinner"
+
+export default function Loading() {
+	return <div className="justify-center w-1/2 h-1/2">
+    <Spinner />
+</div>
+}

--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -53,6 +53,7 @@ const useOwnedTokens = (
 };
 
 export default function Wallet() {
+  const [isInitialized, setIsInitialized] = useState(false);
 	const [contract, setContract] = useState<Contract>(new Contract());
 
 	const [dexOwnedTokens, dexBalances, refreshDexBalances] = useOwnedTokens(
@@ -114,7 +115,9 @@ export default function Wallet() {
 					setTokenPrices(map);
 				})
 				.catch(errorHandler);
-		});
+		}).then(()=> {
+      setIsInitialized(true)
+    });
 
 		connectWallet();
 	}, [contract]);
@@ -343,6 +346,7 @@ export default function Wallet() {
 				} w-full`}
 				tokens={displayTokens}
 				onClick={onTokenSelect}
+        isInitialized={isInitialized}
 			/>
       </Suspense>
 

--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -53,7 +53,7 @@ const useOwnedTokens = (
 };
 
 export default function Wallet() {
-  const [isInitialized, setIsInitialized] = useState(false);
+	const [isInitialized, setIsInitialized] = useState(false);
 	const [contract, setContract] = useState<Contract>(new Contract());
 
 	const [dexOwnedTokens, dexBalances, refreshDexBalances] = useOwnedTokens(

--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -13,7 +13,8 @@ import GGXWallet, { type Account } from "@/services/ggx";
 import TokenDecimals from "@/tokenDecimalsConverter";
 import type { Amount, Token, TokenId } from "@/types";
 import { BN, BN_ZERO } from "@polkadot/util";
-import { type ChangeEvent, useEffect, useRef, useState } from "react";
+import { type ChangeEvent, Suspense, useEffect, useRef, useState } from "react";
+import Loading from "./loading";
 
 type InteractType = "Deposit" | "Withdraw";
 
@@ -334,6 +335,7 @@ export default function Wallet() {
 					)}
 				</div>
 			</div>
+      <Suspense fallback={<Loading />}>
 			<TokenList
 				onChain={true}
 				className={`${
@@ -342,6 +344,7 @@ export default function Wallet() {
 				tokens={displayTokens}
 				onClick={onTokenSelect}
 			/>
+      </Suspense>
 
 			<Modal
 				modalTitle={`${modalTitle.current} ${selectedToken?.name ?? ""}`}

--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -116,7 +116,7 @@ export default function Wallet() {
 				})
 				.catch(errorHandler);
 		}).then(()=> {
-      setIsInitialized(true)
+			setIsInitialized(true)
     });
 
 		connectWallet();

--- a/src/components/__tests__/tokenList.tsx
+++ b/src/components/__tests__/tokenList.tsx
@@ -39,9 +39,12 @@ describe("OrdersList", () => {
 		},
 	];
 
-	test("render empty token list", () => {
+	test("render empty token list", async() => {
 		render(<TokenList tokens={[]} />);
-		expect(screen.getByText("No tokens found")).toBeInTheDocument();
+		setTimeout((done) => {
+			expect(screen.getByText("No tokens found")).toBeInTheDocument()
+			done();
+		}, 2000);
 	});
 
 	test("render correctly without onchaindata", () => {

--- a/src/components/dex/orderList.tsx
+++ b/src/components/dex/orderList.tsx
@@ -27,13 +27,13 @@ export const useUserOrders = (contract: Contract) => {
 interface UserOrderProps {
 	orders: DetailedOrder[];
 	cancelOrder: (order: DetailedOrder) => void;
-  isInitialized: boolean;
+	isInitialized: boolean;
 }
 
 export default function OrdersList({
 	orders,
 	cancelOrder,
-  isInitialized,
+	isInitialized,
 }: Readonly<UserOrderProps>) {
 	const [now, setNow] = useState(Date.now());
 

--- a/src/components/dex/orderList.tsx
+++ b/src/components/dex/orderList.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import { useEffect, useState } from "react";
 import Close from "../common/close";
 import Ruler, { GrayRuler } from "../common/ruler";
+import Spinner from "../common/spinner";
 
 export const useUserOrders = (contract: Contract) => {
 	const [orders, setOrders] = useState<DetailedOrder[]>([]);
@@ -26,11 +27,13 @@ export const useUserOrders = (contract: Contract) => {
 interface UserOrderProps {
 	orders: DetailedOrder[];
 	cancelOrder: (order: DetailedOrder) => void;
+  isInitialized: boolean;
 }
 
 export default function OrdersList({
 	orders,
 	cancelOrder,
+  isInitialized,
 }: Readonly<UserOrderProps>) {
 	const [now, setNow] = useState(Date.now());
 

--- a/src/components/dex/orderList.tsx
+++ b/src/components/dex/orderList.tsx
@@ -155,7 +155,7 @@ export default function OrdersList({
 									</td>
 									<td className="text-left">{expiredText}</td>
 									<td className="rounded-r-xl">
-										<button
+										<button type="button"
 											onClick={() => cancelOrder(order)}
 											className="flex items-center text-GGx-yellow"
 										>

--- a/src/components/tokenList.tsx
+++ b/src/components/tokenList.tsx
@@ -47,13 +47,13 @@ export default function TokenList({
 				</tr>
 			</thead>
 			<tbody>
-        {(!isInitialized && tokens.length === 0) ?
-            <tr><td><div className="flex w-full justify-center">
-              <div className="w-20 h-20 mt-5">
-                <Spinner />
-              </div>
-            </div></td></tr> : null}
-            
+				{(!isInitialized && tokens.length === 0) ?
+					<tr><td><div className="flex w-full justify-center">
+						<div className="w-20 h-20 mt-5">
+							<Spinner />
+						</div>
+					</div></td></tr> : null}
+
 				{(isInitialized && tokens.length === 0) ? (
 					<tr>
 						<td className="text-center">No tokens found</td>

--- a/src/components/tokenList.tsx
+++ b/src/components/tokenList.tsx
@@ -17,7 +17,7 @@ interface TokenListProperties {
 	className?: string;
 	selected?: ListElement;
 	onChain?: boolean;
-  isInitialized?: boolean;
+	isInitialized?: boolean;
 }
 
 export default function TokenList({
@@ -26,7 +26,7 @@ export default function TokenList({
 	className,
 	selected,
 	onChain,
-  isInitialized,
+	isInitialized,
 }: Readonly<TokenListProperties>) {
 	const handleClick = (token: ListElement) => {
 		if (onClick !== undefined) {

--- a/src/components/tokenList.tsx
+++ b/src/components/tokenList.tsx
@@ -2,6 +2,7 @@ import TokenDecimals from "@/tokenDecimalsConverter";
 import type { Amount, Token } from "@/types";
 import { BN_ZERO } from "@polkadot/util";
 import Image from "next/image";
+import Spinner from "./common/spinner";
 
 export interface ListElement extends Token {
 	balance: Amount;
@@ -16,6 +17,7 @@ interface TokenListProperties {
 	className?: string;
 	selected?: ListElement;
 	onChain?: boolean;
+  isInitialized?: boolean;
 }
 
 export default function TokenList({
@@ -24,6 +26,7 @@ export default function TokenList({
 	className,
 	selected,
 	onChain,
+  isInitialized,
 }: Readonly<TokenListProperties>) {
 	const handleClick = (token: ListElement) => {
 		if (onClick !== undefined) {
@@ -44,11 +47,18 @@ export default function TokenList({
 				</tr>
 			</thead>
 			<tbody>
-				{tokens.length === 0 && (
+        {(!isInitialized && tokens.length === 0) ?
+            <tr><td><div className="flex w-full justify-center">
+              <div className="w-20 h-20 mt-5">
+                <Spinner />
+              </div>
+            </div></td></tr> : null}
+            
+				{(isInitialized && tokens.length === 0) ? (
 					<tr>
 						<td className="text-center">No tokens found</td>
-					</tr>
-				)}
+					</tr>) : null
+				}
 
 				{tokens.map((token) => {
 					const isSelected = token.id === selected?.id;


### PR DESCRIPTION
I have added loading files and Suspense wrapping Tokenlist in Wallet and Transfer pages, Suspense wrapping OrderBook and OrderList in Dex page. But they are not working because the TokenList, OrderBook, and OrderList themselves do not fetch async data inside themselves, hence Suspense loading do not get triggered.
As a workaround, I added some states in those pages to manually trigger the loading spinner to show initially. Moving async code into Tokenlist, OrderBook, OrderList would be a big change in the future.
See result demo: https://drive.google.com/file/d/1-0Z6xE5YZdwmYON4VFLcWgZ3IukganyG/view?ts=66179532
Dex page OrderList(My orders) has not been added with my manual loading trigger.